### PR TITLE
Add Socket constructor and complimentary createIO function.

### DIFF
--- a/common/src/main/java/org/robockets/runqueue/common/SocketWrapper.java
+++ b/common/src/main/java/org/robockets/runqueue/common/SocketWrapper.java
@@ -111,6 +111,19 @@ public class SocketWrapper extends Socket {
 	
 	/**
 	*
+	*	Using an already created {@link java.net.Socket} set up a SocketWrapper I/O.
+	*
+	*	@param socket			an already created socket, presumably from ServerSocket.accept()
+	*
+	*	@see java.net.Socket
+	*
+	**/
+	public SocketWrapper (Socket socket) throws IOException {
+		createIO(socket);
+	}
+	
+	/**
+	*
 	*	Create the {@link java.io.InputStream} and {@link java.io.OutputStream} used by the {@link SocketWrapper}.
 	*
 	**/
@@ -120,6 +133,23 @@ public class SocketWrapper extends Socket {
 			lineOut = getOutputStream();
 		} catch (Exception ex) {
 			System.err.println("Could not initiate SocketWrapper I/O.");
+			ex.printStackTrace();
+		}
+	}
+	
+	/**
+	*
+	*	Create the {@link java.io.InputStream} and {@link java.io.OutputStream} used by the {@link SocketWrapper} with a given socket.
+	*
+	*	@param socket			the socket to create input and output streams from
+	*
+	**/
+	private void createIO (Socket socket) {
+		try {
+			lineIn = socket.getInputStream();
+			lineOut = socket.getOutputStream();
+		} catch (Exception ex) {
+			System.err.println("Could not initiate SocketWrapper I/O with given socket.");
 			ex.printStackTrace();
 		}
 	}


### PR DESCRIPTION
This recent change was delayed due to the big merge and it got lost in the
sands of time (or something). This change was made because there was a need for
a way to use SocketWrapper with it's nice methods and enums and general
beautiful interface with a ServerSocket, which surprisingly is not an subclass
of a Socket but rather a whole new class derived from nothing. To add onto the
issues one in Java cannot cast an object into a subclass of that object for
some technical reasons.

And so I created two things:
- A constructor
- A createIO method

I noticed that the whole SocketWrapper was really just manipulating the input
and output streams and thus it wasn't interacting with itself, or it's
superclass beyond the constructors and createIO. So I made a constructor that
takes a Socket instance and then calls a special createIO private method, one
that itself takes a socket instance and creates input and output streams with
it.

Maybe my explanation was overkill.
